### PR TITLE
refactor: mdx-components.tsxをNextra v4の公式手順に合わせる

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,1 +1,10 @@
-export { useMDXComponents } from 'nextra-theme-docs';
+import { useMDXComponents as getThemeComponents } from 'nextra-theme-docs';
+
+import type { MDXComponents } from 'nextra/mdx-components';
+
+const themeComponents = getThemeComponents();
+
+export const useMDXComponents = (components?: MDXComponents) => ({
+  ...themeComponents,
+  ...components,
+});


### PR DESCRIPTION
## これなに

`mdx-components.tsx` を [Nextra v4 の公式手順](https://nextra.site/docs/file-conventions/mdx-components-file)に合わせて書き直しました。