### PR TITLE
feat: Google FormにGAと紐づけるためのclient idが埋め込んだ

### DIFF
--- a/app/components/google-form-client-id-prefill.tsx
+++ b/app/components/google-form-client-id-prefill.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import type { FC } from 'react';
+
+const GOOGLE_FORM_URL = 'docs.google.com/forms/d/1whmNgig8TKm8qTvAAYm5xjYE';
+const ENTRY_KEY = 'entry.883602885';
+const GA_COOKIE_PATTERN = /_ga=GA\d\.\d\.(\d+\.\d+)/;
+
+const readClientId = () => {
+  const match = document.cookie.match(GA_COOKIE_PATTERN);
+  return match?.[1] || '';
+};
+
+export const GoogleFormClientIdPrefill: FC = () => {
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const anchor = target.closest('a');
+      if (!anchor || !anchor.href.includes(GOOGLE_FORM_URL)) return;
+
+      const clientId = readClientId();
+      if (!clientId) return;
+
+      const url = new URL(anchor.href);
+      url.searchParams.set(ENTRY_KEY, clientId);
+      url.searchParams.set('usp', 'pp_url');
+      anchor.href = url.toString();
+    };
+
+    document.addEventListener('click', handleClick, true);
+    return () => document.removeEventListener('click', handleClick, true);
+  }, []);
+
+  return null;
+};

--- a/app/components/google-form-client-id-prefill.tsx
+++ b/app/components/google-form-client-id-prefill.tsx
@@ -15,7 +15,7 @@ const readClientId = () => {
 
 export const GoogleFormClientIdPrefill: FC = () => {
   useEffect(() => {
-    const handleClick = (event: MouseEvent) => {
+    const handlePrefill = (event: Event) => {
       const target = event.target;
       if (!(target instanceof Element)) return;
 
@@ -31,8 +31,13 @@ export const GoogleFormClientIdPrefill: FC = () => {
       anchor.href = url.toString();
     };
 
-    document.addEventListener('click', handleClick, true);
-    return () => document.removeEventListener('click', handleClick, true);
+    // clickは左クリックしか捕捉できないため、中クリックやCtrl+クリックにも対応できるようpointerdownでも書き換える
+    document.addEventListener('pointerdown', handlePrefill, true);
+    document.addEventListener('click', handlePrefill, true);
+    return () => {
+      document.removeEventListener('pointerdown', handlePrefill, true);
+      document.removeEventListener('click', handlePrefill, true);
+    };
   }, []);
 
   return null;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,8 @@ import { Head } from 'nextra/components';
 import { getPageMap } from 'nextra/page-map';
 import { Footer, Layout, Navbar } from 'nextra-theme-docs';
 
+import { GoogleFormClientIdPrefill } from './components/google-form-client-id-prefill';
+
 import type { Metadata } from 'next';
 import type { FC, PropsWithChildren } from 'react';
 
@@ -37,6 +39,7 @@ const RootLayout: FC<PropsWithChildren> = async ({ children }) => {
         <GoogleTagManager gtmId="GTM-M5B86HFP" />
       </Head>
       <body>
+        <GoogleFormClientIdPrefill />
         <Layout
           navbar={(
             <Navbar logo={<b>PrAha Entrance Book</b>} projectLink="https://github.com/praha-inc/entrance-book" />


### PR DESCRIPTION
# 概要
表題の通りです

# 変更内容

GAがセットするcookieからclient idを読み込んでGoogle Formのprefilled機能を使ってGoogle Formのユーザ情報セクションにclient idが埋め込まれるようにしました。
これによりカジュアル面談に応募した流入データをGA上でも閲覧できるようになります。