### PR TITLE
chore: エンジニアの年収データを2026年8月時点の情報に更新

### DIFF
--- a/app/numbers/page.mdx
+++ b/app/numbers/page.mdx
@@ -6,8 +6,8 @@ import { SalaryChart } from '../components/salary-chart';
 
 ## エンジニアの年収データ
 
-- 平均年収: 887.46万円
-- 中央年収: 895.0万円
+- 平均年収: 947.54万円
+- 中央年収: 955.0万円
 
 <SalaryChart
   data={[
@@ -15,7 +15,7 @@ import { SalaryChart } from '../components/salary-chart';
     { period: '2023年', average: 683.7, median: 673 },
     { period: '2024年', average: 798.1, median: 774.5 },
     { period: '2025年', average: 867.67, median: 873.5 },
-    { period: '2026年', average: 887.46, median: 895.0 },
+    { period: '2026年', average: 947.54, median: 955.0 },
   ]}
 />
 


### PR DESCRIPTION
## 概要

エンジニア年収データを最新の値に更新しました。

<img width="939" height="559" alt="スクリーンショット 2026-08-21 16 45 04" src="https://github.com/user-attachments/assets/906bb32e-5ced-4ce1-b9b2-1a12f394d119" />


